### PR TITLE
Deploy Galera on the monitoring nodes for Grafana

### DIFF
--- a/classes/cluster/mk22_lab_advanced/stacklight/server.yml
+++ b/classes/cluster/mk22_lab_advanced/stacklight/server.yml
@@ -2,6 +2,7 @@ classes:
 - system.linux.system.repo.grafana
 - system.linux.system.repo.influxdb
 - system.linux.system.repo.tcp_elastic
+- system.linux.system.repo.mos9
 - system.collectd.remote_client.cluster
 - system.heka.remote_collector.cluster
 - system.heka.remote_collector.input.amqp
@@ -30,11 +31,11 @@ parameters:
     cluster_elasticsearch_port: 9200
     cluster_kibana_port: 5601
     cluster_grafana_port: 3000
-    cluster_node01_name: mon01
+    cluster_node01_hostname: mon01
     cluster_node01_address: ${_param:stacklight_monitor_node01_address}
-    cluster_node02_name: mon02
+    cluster_node02_hostname: mon02
     cluster_node02_address: ${_param:stacklight_monitor_node02_address}
-    cluster_node03_name: mon03
+    cluster_node03_hostname: mon03
     cluster_node03_address: ${_param:stacklight_monitor_node03_address}
   linux:
     network:

--- a/classes/cluster/mk22_lab_dvr/infra/config.yml
+++ b/classes/cluster/mk22_lab_dvr/infra/config.yml
@@ -73,3 +73,18 @@ parameters:
         openstack_proxy_node01:
           classes:
           - cluster.mk22_lab_dvr.stacklight.proxy
+        stacklight_server_node01:
+          classes:
+          - service.galera.master.cluster
+          params:
+            mysql_cluster_role: master
+        stacklight_server_node02:
+          classes:
+          - service.galera.slave.cluster
+          params:
+            mysql_cluster_role: slave
+        stacklight_server_node03:
+          classes:
+          - service.galera.slave.cluster
+          params:
+            mysql_cluster_role: slave

--- a/classes/cluster/mk22_lab_dvr/openstack/control.yml
+++ b/classes/cluster/mk22_lab_dvr/openstack/control.yml
@@ -31,7 +31,6 @@ classes:
 - system.galera.server.database.ceilometer
 - system.galera.server.database.cinder
 - system.galera.server.database.glance
-- system.galera.server.database.grafana
 - system.galera.server.database.heat
 - system.galera.server.database.keystone
 - system.galera.server.database.nova

--- a/classes/cluster/mk22_lab_dvr/stacklight/server.yml
+++ b/classes/cluster/mk22_lab_dvr/stacklight/server.yml
@@ -1,7 +1,9 @@
 classes:
+- service.haproxy.proxy.single
 - system.linux.system.repo.grafana
 - system.linux.system.repo.influxdb
 - system.linux.system.repo.tcp_elastic
+- system.linux.system.repo.mos9
 - system.collectd.remote_client.cluster
 - system.heka.remote_collector.cluster
 - system.heka.remote_collector.input.amqp
@@ -11,12 +13,13 @@ classes:
 - system.kibana.server.single
 - system.grafana.server.single
 - system.nagios.server.cluster
-- cluster.mk22_lab_dvr
 - system.haproxy.proxy.listen.stacklight.elasticsearch
 - system.haproxy.proxy.listen.stacklight.kibana
 - system.haproxy.proxy.listen.stacklight.grafana
-- service.haproxy.proxy.single
 - system.keepalived.cluster.instance.stacklight_monitor_vip
+- system.galera.server.cluster
+- system.galera.server.database.grafana
+- cluster.mk22_lab_dvr
 parameters:
   _param:
     collectd_remote_collector_host: ${_param:stacklight_monitor_address}
@@ -29,11 +32,11 @@ parameters:
     cluster_elasticsearch_port: 9200
     cluster_kibana_port: 5601
     cluster_grafana_port: 3000
-    cluster_node01_name: mon01
+    cluster_node01_hostname: mon01
     cluster_node01_address: ${_param:stacklight_monitor_node01_address}
-    cluster_node02_name: mon02
+    cluster_node02_hostname: mon02
     cluster_node02_address: ${_param:stacklight_monitor_node02_address}
-    cluster_node03_name: mon03
+    cluster_node03_hostname: mon03
     cluster_node03_address: ${_param:stacklight_monitor_node03_address}
   linux:
     network:


### PR DESCRIPTION
Grafana requires a MySQL backend for storing credentials and
dashboards. Previously it piggy-backed on the OpenStack Galera cluster
but if the cluster is down or unreachable, Grafana is down too. This
change deploys a Galera cluster on the monitoring nodes instead.