### PR TITLE
Add model for splitted Contrail services

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,3 +75,15 @@ Mk.22 advanced testing lab
 * 3 control nodes
 * 2 compute nodes
 * 3 monitoring nodes
+
+
+Mk.22 splitted contrail testing lab
+-----------------------------------
+
+* 1 config node
+* 3 OpenStack control nodes
+* 3 OpenContrail control nodes
+* 3 OpenContrail analytics nodes
+* 1 Proxy/Gateway node
+* 1 compute node
+* 1 monitor node

--- a/classes/cluster/mk22_splitted_contrail/fuel/config.yml
+++ b/classes/cluster/mk22_splitted_contrail/fuel/config.yml
@@ -1,0 +1,62 @@
+classes:
+- service.git.client
+- system.linux.system.single
+- system.linux.system.repo.tcp_salt
+- system.openssh.client.lab
+- system.salt.master.pkg
+- system.reclass.storage.salt
+- system.salt.minion.ca.salt_master
+- system.salt.minion.cert.proxy
+- system.sphinx.server.doc.reclass
+- system.keystone.client.single
+- system.keystone.client.service.aodh
+- system.keystone.client.service.ceilometer
+- system.keystone.client.service.nova21
+- system.mysql.client.single
+- system.reclass.storage.system.opencontrail_analytics_cluster
+- system.reclass.storage.system.opencontrail_control_cluster
+- system.reclass.storage.system.opencontrail_gateway_single
+- system.reclass.storage.system.openstack_control_cluster
+- system.reclass.storage.system.openstack_compute_single
+- system.reclass.storage.system.openstack_dashboard_single
+- system.reclass.storage.system.openstack_proxy_single
+- system.reclass.storage.system.stacklight_server_single
+- cluster.mk22_splitted_contrail
+parameters:
+  _param:
+    reclass_data_repository: "git@github.com:Mirantis/stacklight-salt-model.git"
+    reclass_data_revision: master
+    reclass_config_master: 192.168.10.100
+    single_address: 172.16.10.100
+    salt_master_host: 127.0.0.1
+    salt_master_base_environment: prd
+    salt_minion_ca_host: ${linux:network:fqdn}
+    salt_master_api_port: 8088
+  linux:
+    network:
+      interface:
+        ens4:
+          enabled: true
+          type: eth
+          proto: dhcp
+  reclass:
+    storage:
+      node:
+        openstack_control_node01:
+          classes:
+          - service.galera.master.cluster
+          params:
+            mysql_cluster_role: master
+        openstack_control_node02:
+          classes:
+          - service.galera.slave.cluster
+          params:
+            mysql_cluster_role: slave
+        openstack_control_node03:
+          classes:
+          - service.galera.slave.cluster
+          params:
+            mysql_cluster_role: slave
+        openstack_proxy_node01:
+          classes:
+          - cluster.mk22_splitted_contrail.stacklight.proxy

--- a/classes/cluster/mk22_splitted_contrail/fuel/init.yml
+++ b/classes/cluster/mk22_splitted_contrail/fuel/init.yml
@@ -1,0 +1,14 @@
+parameters:
+  linux:
+    network:
+      host:
+        cfg01:
+          address: ${_param:fuel_config_address}
+          names:
+          - cfg01
+          - cfg01.${_param:cluster_domain}
+        cfg:
+          address: ${_param:fuel_config_address}
+          names:
+          - cfg
+          - cfg.${_param:cluster_domain}

--- a/classes/cluster/mk22_splitted_contrail/init.yml
+++ b/classes/cluster/mk22_splitted_contrail/init.yml
@@ -1,0 +1,74 @@
+classes:
+- system.linux.system.single
+- system.rsyslog.client.single
+- system.openssh.server.team.lab
+- cluster.mk22_splitted_contrail.fuel
+- cluster.mk22_splitted_contrail.opencontrail
+- cluster.mk22_splitted_contrail.openstack
+- cluster.mk22_splitted_contrail.stacklight
+- cluster.mk22_splitted_contrail.stacklight.client
+parameters:
+  _param:
+    cluster_domain: mk22-splitted-contrail.local
+    cluster_name: mk22_splitted_contrail
+    cluster_public_host: _
+
+    # fuel service addresses
+    fuel_config_address: 172.16.10.100
+
+    # openstack service addresses
+    openstack_proxy_address: 172.16.10.121
+    openstack_proxy_node01_address: 172.16.10.121
+
+    openstack_control_address: 172.16.10.254
+    openstack_control_node01_address: 172.16.10.101
+    openstack_control_node02_address: 172.16.10.102
+    openstack_control_node03_address: 172.16.10.103
+
+    openstack_database_address: ${_param:openstack_control_address}
+    openstack_database_node01_address: ${_param:openstack_control_node01_address}
+    openstack_database_node02_address: ${_param:openstack_control_node02_address}
+    openstack_database_node03_address: ${_param:openstack_control_node02_address}
+
+    openstack_message_queue_address: ${_param:openstack_control_address}
+    openstack_message_queue_node01_address: ${_param:openstack_control_node01_address}
+    openstack_message_queue_node02_address: ${_param:openstack_control_node02_address}
+    openstack_message_queue_node03_address: ${_param:openstack_control_node03_address}
+
+    # opencontrail service addresses
+    analytics_vip_address: 172.16.10.249
+    opencontrail_analytics_address: 172.16.10.249
+    opencontrail_analytics_node01_address: 172.16.10.171
+    opencontrail_analytics_node02_address: 172.16.10.172
+    opencontrail_analytics_node03_address: 172.16.10.173
+
+    network_vip_address: 172.16.10.250
+    opencontrail_control_address: 172.16.10.250
+    opencontrail_control_node01_address: 172.16.10.161
+    opencontrail_control_node02_address: 172.16.10.162
+    opencontrail_control_node03_address: 172.16.10.163
+    opencontrail_gateway_address: 172.16.10.131
+
+    # stacklight service addresses
+    stacklight_monitor_address: 172.16.10.107
+    stacklight_monitor_node01_address: 172.16.10.107
+    stacklight_telemetry_node01_address: ${_param:stacklight_monitor_node01_address}
+    stacklight_log_address: ${_param:stacklight_monitor_address}
+
+    # openstack compute nodes
+    openstack_compute_node01_address: 172.16.10.105
+
+    # Interface definitions
+    linux_dhcp_interface:
+      enabled: true
+      type: eth
+      proto: dhcp
+    linux_static_interface:
+      enabled: true
+      type: eth
+      proto: static
+      address: ${_param:single_address}
+      netmask: 255.255.255.0
+      gateway: 172.16.10.1
+      name_servers:
+        - 8.8.8.8

--- a/classes/cluster/mk22_splitted_contrail/opencontrail/analytics.yml
+++ b/classes/cluster/mk22_splitted_contrail/opencontrail/analytics.yml
@@ -1,0 +1,34 @@
+classes:
+- system.linux.system.repo.contrail
+- system.linux.system.repo.mos8
+- system.opencontrail.control.analytics
+- cluster.mk22_splitted_contrail
+parameters:
+  _param:
+    keepalived_vip_interface: eth1
+    keepalived_vip_virtual_router_id: 70
+    cluster_vip_address: ${_param:opencontrail_analytics_address}
+    cluster_local_address: ${_param:single_address}
+    cluster_node01_hostname: nal01
+    cluster_node01_address: ${_param:opencontrail_analytics_node01_address}
+    cluster_node02_hostname: nal02
+    cluster_node02_address: ${_param:opencontrail_analytics_node02_address}
+    cluster_node03_hostname: nal03
+    cluster_node03_address: ${_param:opencontrail_analytics_node03_address}
+  linux:
+    network:
+      interface:
+        eth1: ${_param:linux_static_interface}
+  opencontrail:
+    common:
+      identity:
+        host: ${_param:openstack_control_address}
+    collector:
+      discovery:
+        host: ${_param:opencontrail_control_address}
+    database:
+      discovery:
+        host: ${_param:opencontrail_control_address}
+    common:
+      network:
+        host: ${_param:opencontrail_control_address}

--- a/classes/cluster/mk22_splitted_contrail/opencontrail/control.yml
+++ b/classes/cluster/mk22_splitted_contrail/opencontrail/control.yml
@@ -1,0 +1,28 @@
+classes:
+- system.linux.system.repo.contrail
+- system.linux.system.repo.mos8
+- system.neutron.control.cluster
+- system.opencontrail.control.control
+- cluster.mk22_splitted_contrail
+parameters:
+  _param:
+    keepalived_vip_interface: eth1
+    keepalived_vip_virtual_router_id: 60
+    cluster_vip_address: ${_param:opencontrail_control_address}
+    cluster_local_address: ${_param:single_address}
+    cluster_node01_hostname: ntw01
+    cluster_node01_address: ${_param:opencontrail_control_node01_address}
+    cluster_node02_hostname: ntw02
+    cluster_node02_address: ${_param:opencontrail_control_node02_address}
+    cluster_node03_hostname: ntw03
+    cluster_node03_address: ${_param:opencontrail_control_node03_address}
+  linux:
+    network:
+      interface:
+        eth1: ${_param:linux_static_interface}
+      host:
+        ctl:
+          address: ${_param:openstack_control_address}
+          names:
+          - ctl
+          - ctl.${_param:cluster_domain}

--- a/classes/cluster/mk22_splitted_contrail/opencontrail/gateway.yml
+++ b/classes/cluster/mk22_splitted_contrail/opencontrail/gateway.yml
@@ -1,0 +1,2 @@
+classes:
+- cluster.mk22_splitted_contrail

--- a/classes/cluster/mk22_splitted_contrail/opencontrail/init.yml
+++ b/classes/cluster/mk22_splitted_contrail/opencontrail/init.yml
@@ -1,0 +1,52 @@
+parameters:
+  _param:
+    opencontrail_version: 3.0
+    opencontrail_stats_password: contrail123
+    opencontrail_compute_dns: 8.8.8.8
+    opencontrail_compute_gateway: 172.16.10.1
+    opencontrail_compute_address: ${_param:single_address}
+    opencontrail_compute_iface: eth1
+    opencontrail_compute_iface_mask: 24
+  linux:
+    network:
+      host:
+        ntw:
+          address: ${_param:opencontrail_control_address}
+          names:
+          - ntw
+          - ntw.${_param:cluster_domain}
+        ntw01:
+          address: ${_param:opencontrail_control_node01_address}
+          names:
+          - ntw01
+          - ntw01.${_param:cluster_domain}
+        ntw02:
+          address: ${_param:opencontrail_control_node02_address}
+          names:
+          - ntw02
+          - ntw02.${_param:cluster_domain}
+        ntw03:
+          address: ${_param:opencontrail_control_node03_address}
+          names:
+          - ntw03
+          - ntw03.${_param:cluster_domain}
+        nal:
+          address: ${_param:opencontrail_analytics_address}
+          names:
+          - nal
+          - nal.${_param:cluster_domain}
+        nal01:
+          address: ${_param:opencontrail_analytics_node01_address}
+          names:
+          - nal01
+          - nal01.${_param:cluster_domain}
+        nal02:
+          address: ${_param:opencontrail_analytics_node02_address}
+          names:
+          - nal02
+          - nal02.${_param:cluster_domain}
+        nal03:
+          address: ${_param:opencontrail_analytics_node03_address}
+          names:
+          - nal03
+          - nal03.${_param:cluster_domain}

--- a/classes/cluster/mk22_splitted_contrail/openstack/compute.yml
+++ b/classes/cluster/mk22_splitted_contrail/openstack/compute.yml
@@ -1,0 +1,59 @@
+classes:
+- system.linux.system.repo.contrail
+- system.linux.system.repo.mos9
+- system.nova.compute.cluster
+- system.ceilometer.agent.cluster
+- system.opencontrail.compute.cluster
+- system.heka.alarm.openstack_compute
+- service.opencontrail.compute.cluster
+- cluster.mk22_splitted_contrail
+parameters:
+  _param:
+    cluster_vip_address: ${_param:openstack_control_address}
+    cluster_local_address: ${_param:single_address}
+    cluster_node01_hostname: ctl01
+    cluster_node01_address: ${_param:openstack_control_node01_address}
+    cluster_node02_hostname: ctl02
+    cluster_node02_address: ${_param:openstack_control_node02_address}
+    cluster_node03_hostname: ctl03
+    cluster_node03_address: ${_param:openstack_control_node03_address}
+    opencontrail_compute_address: ${_param:single_address}
+    opencontrail_compute_gateway: 172.16.10.1
+    opencontrail_compute_iface: eth1
+  linux:
+    network:
+      interface:
+        eth1:
+          enabled: true
+          type: eth
+          proto: manual
+        vhost0:
+          enabled: true
+          type: eth
+          mtu: 1500
+          address: ${_param:single_address}
+          netmask: '255.255.255.0'
+          pre_up_cmds:
+          - /usr/lib/contrail/if-vhost0
+          use_interfaces:
+          - eth1
+  nova:
+    compute:
+      vncproxy_url: http://${_param:cluster_vip_address}:6080
+      notification:
+        driver: messagingv2
+        topics: "notifications,${_param:stacklight_notification_topic}"
+        notify_on:
+          state_change: vm_and_task_state
+      message_queue:
+        members:
+          - host: ${_param:openstack_control_node01_address}
+          - host: ${_param:openstack_control_node02_address}
+          - host: ${_param:openstack_control_node03_address}
+  ceilometer:
+    agent:
+      message_queue:
+        members:
+          - host: ${_param:openstack_control_node01_address}
+          - host: ${_param:openstack_control_node02_address}
+          - host: ${_param:openstack_control_node03_address}

--- a/classes/cluster/mk22_splitted_contrail/openstack/control.yml
+++ b/classes/cluster/mk22_splitted_contrail/openstack/control.yml
@@ -1,0 +1,118 @@
+classes:
+- system.linux.system.lowmem
+- system.linux.system.repo.contrail
+- system.linux.system.repo.mos9
+- system.linux.system.repo.mos9_latest
+- system.linux.system.repo.tcp_extra
+- system.memcached.server.single
+- system.rabbitmq.server.cluster
+- system.rabbitmq.server.vhost.openstack
+- system.keystone.server.cluster
+- system.keystone.server.storage.glusterfs
+- system.glance.control.cluster
+- system.glance.control.storage.glusterfs
+- system.nova.control.cluster
+- system.neutron.control.opencontrail.cluster
+- system.cinder.control.cluster
+- system.heat.server.cluster
+- system.ceilometer.server.cluster
+- system.ceilometer.server.backend.influxdb
+- system.aodh.server.cluster
+- system.opencontrail.control.cluster
+- system.heka.ceilometer_collector.single
+- system.galera.server.cluster
+- system.galera.server.database.aodh
+- system.galera.server.database.ceilometer
+- system.galera.server.database.cinder
+- system.galera.server.database.glance
+- system.galera.server.database.grafana
+- system.galera.server.database.heat
+- system.galera.server.database.keystone
+- system.galera.server.database.nova
+- system.heka.alarm.openstack_control
+- cluster.mk22_splitted_contrail
+parameters:
+  _param:
+    keepalived_vip_interface: eth1
+    cluster_vip_address: ${_param:openstack_control_address}
+    cluster_local_address: ${_param:single_address}
+    cluster_node01_hostname: ctl01
+    cluster_node01_address: ${_param:openstack_control_node01_address}
+    cluster_node02_hostname: ctl02
+    cluster_node02_address: ${_param:openstack_control_node02_address}
+    cluster_node03_hostname: ctl03
+    cluster_node03_address: ${_param:openstack_control_node03_address}
+  linux:
+    system:
+      package:
+        python-msgpack:
+          version: latest
+    network:
+      interface:
+        eth1:
+          enabled: true
+          type: eth
+          proto: dhcp
+  keepalived:
+    cluster:
+      instance:
+        VIP:
+          virtual_router_id: 150
+  keystone:
+    server:
+      admin_email: ${_param:admin_email}
+      notification:
+        driver: messagingv2
+        topics: "notifications,${_param:stacklight_notification_topic}"
+  glance:
+    server:
+      storage:
+        engine: file
+      images: []
+      workers: 1
+      notification:
+        driver: messagingv2
+        topics: "notifications,${_param:stacklight_notification_topic}"
+  heat:
+    server:
+      notification:
+        driver: messagingv2
+        topics: "notifications,${_param:stacklight_notification_topic}"
+  nova:
+    controller:
+      networking: contrail
+      cpu_allocation: 54
+      bind:
+        private_address: ${_param:cluster_local_address}
+        public_address: ${_param:cluster_vip_address}
+        novncproxy_port: 6080
+      vncproxy_url: http://${_param:cluster_vip_address}:6080
+      cache:
+        engine: memcached
+        prefix: CACHE_NOVA
+        members:
+        - host: 127.0.0.1
+          port: 11211
+      workers: 1
+      notification:
+        driver: messagingv2
+        topics: "notifications,${_param:stacklight_notification_topic}"
+  neutron:
+    server:
+      plugin: contrail
+      tunnel_type: vxlan
+      public_networks: []
+      contrail:
+        version: ${_param:opencontrail_version}
+      notification:
+        driver: messagingv2
+        topics: "notifications,${_param:stacklight_notification_topic}"
+  cinder:
+    volume:
+      notification:
+        driver: messagingv2
+        topics: "notifications,${_param:stacklight_notification_topic}"
+    controller:
+      notification:
+        driver: messagingv2
+        topics: "notifications,${_param:stacklight_notification_topic}"

--- a/classes/cluster/mk22_splitted_contrail/openstack/dashboard.yml
+++ b/classes/cluster/mk22_splitted_contrail/openstack/dashboard.yml
@@ -1,0 +1,17 @@
+classes:
+- system.linux.system.repo.tcp_base
+- system.horizon.server.single
+- system.sphinx.server.doc.reclass
+- cluster.mk22_splitted_contrail
+parameters:
+  linux:
+    system:
+      repo:
+        tcpcloud_openstack:
+          source: deb [arch=amd64] http://apt.tcpcloud.eu/nightly/ trusty liberty
+    network:
+      interface:
+        eth1:
+          enabled: true
+          type: eth
+          proto: dhcp

--- a/classes/cluster/mk22_splitted_contrail/openstack/init.yml
+++ b/classes/cluster/mk22_splitted_contrail/openstack/init.yml
@@ -1,0 +1,107 @@
+parameters:
+  _param:
+    openstack_version: mitaka
+    openstack_region: RegionOne
+    admin_email: root@localhost
+    opencontrail_version: 3.0
+    opencontrail_compute_dns: 8.8.8.8
+    opencontrail_stats_password: contrail123
+    galera_server_cluster_name: openstack_cluster
+    galera_server_maintenance_password: workshop
+    galera_server_admin_password: workshop
+    rabbitmq_secret_key: workshop
+    rabbitmq_admin_password: workshop
+    rabbitmq_openstack_password: workshop
+    rabbitmq_cold_password: workshop
+    glance_version: ${_param:openstack_version}
+    glance_service_host: ${_param:openstack_control_address}
+    keystone_version: ${_param:openstack_version}
+    keystone_service_host: ${_param:openstack_control_address}
+    heat_version: ${_param:openstack_version}
+    heat_service_host: ${_param:openstack_control_address}
+    heat_domain_admin_password: workshop
+    ceilometer_version: ${_param:openstack_version}
+    ceilometer_service_host: ${_param:openstack_control_address}
+    aodh_version: ${_param:openstack_version}
+    aodh_service_host: ${_param:openstack_control_address}
+    cinder_version: ${_param:openstack_version}
+    cinder_service_host: ${_param:openstack_control_address}
+    ceilometer_graphite_publisher_host: 172.16.10.107
+    ceilometer_graphite_publisher_port: 2013
+    nova_version: ${_param:openstack_version}
+    nova_service_host: ${_param:openstack_control_address}
+    nova_vncproxy_url: http://${_param:openstack_control_address}:8060
+    neutron_version: ${_param:openstack_version}
+    neutron_service_host: ${_param:opencontrail_control_address}
+    glusterfs_service_host: ${_param:openstack_control_address}
+    mysql_admin_user: root
+    mysql_admin_password: workshop
+    mysql_aodh_password: workshop
+    mysql_cinder_password: workshop
+    mysql_ceilometer_password: workshop
+    mysql_glance_password: workshop
+    mysql_grafana_password: workshop
+    mysql_heat_password: workshop
+    mysql_keystone_password: workshop
+    mysql_neutron_password: workshop
+    mysql_nova_password: workshop
+    keystone_service_token: workshop
+    keystone_admin_password: workshop
+    keystone_aodh_password: workshop
+    keystone_ceilometer_password: workshop
+    keystone_cinder_password: workshop
+    keystone_glance_password: workshop
+    keystone_heat_password: workshop
+    keystone_keystone_password: workshop
+    keystone_neutron_password: workshop
+    keystone_nova_password: workshop
+    ceilometer_secret_key: workshop
+    horizon_version: ${_param:openstack_version}
+    horizon_secret_key: opaesee8Que2yahJoh9fo0eefo1Aeyo6ahyei8zeiboh3aeth5loth7ieNa5xi5e
+    horizon_identity_host: ${_param:openstack_control_address}
+    horizon_identity_encryption: none
+    horizon_identity_version: 3
+    mongodb_server_replica_set: ceilometer
+    mongodb_ceilometer_password: cloudlab
+    mongodb_admin_password: cloudlab
+    mongodb_shared_key: eoTh1AwahlahqueingeejooLughah4tei9feing0eeVaephooDi2li1TaeV1ooth
+    ceilometer_influxdb_password: lmapass
+
+  linux:
+    network:
+      host:
+        prx:
+          address: ${_param:openstack_proxy_address}
+          names:
+          - prx
+          - prx.${_param:cluster_domain}
+        prx01:
+          address: ${_param:openstack_proxy_node01_address}
+          names:
+          - prx01
+          - prx01.${_param:cluster_domain}
+        ctl:
+          address: ${_param:openstack_control_address}
+          names:
+          - ctl
+          - ctl.${_param:cluster_domain}
+        ctl01:
+          address: ${_param:openstack_control_node01_address}
+          names:
+          - ctl01
+          - ctl01.${_param:cluster_domain}
+        ctl02:
+          address: ${_param:openstack_control_node02_address}
+          names:
+          - ctl02
+          - ctl02.${_param:cluster_domain}
+        ctl03:
+          address: ${_param:openstack_control_node03_address}
+          names:
+          - ctl03
+          - ctl03.${_param:cluster_domain}
+        cmp01:
+          address: 172.16.10.105
+          names:
+          - cmp01
+          - cmp01.${_param:cluster_domain}

--- a/classes/cluster/mk22_splitted_contrail/openstack/proxy.yml
+++ b/classes/cluster/mk22_splitted_contrail/openstack/proxy.yml
@@ -1,0 +1,17 @@
+classes:
+- system.nginx.server.single
+- system.nginx.server.proxy.opencontrail_web
+- system.nginx.server.proxy.openstack_api
+- system.nginx.server.proxy.openstack_vnc
+- system.nginx.server.proxy.openstack_web
+- system.salt.minion.cert.proxy
+- cluster.mk22_splitted_contrail
+parameters:
+  _param:
+    cluster_vip_address: ${_param:openstack_proxy_address}
+    nginx_proxy_ssl:
+      enabled: true
+      authority: ${_param:salt_minion_ca_authority}
+      engine: salt
+      mode: secure
+    salt_minion_ca_host: cfg01.${_param:cluster_domain}

--- a/classes/cluster/mk22_splitted_contrail/stacklight/client.yml
+++ b/classes/cluster/mk22_splitted_contrail/stacklight/client.yml
@@ -1,0 +1,5 @@
+classes:
+- system.collectd.client.output.heka
+- system.heka.log_collector.single
+- system.heka.metric_collector.single
+- service.grafana.collector

--- a/classes/cluster/mk22_splitted_contrail/stacklight/init.yml
+++ b/classes/cluster/mk22_splitted_contrail/stacklight/init.yml
@@ -1,0 +1,50 @@
+parameters:
+  _param:
+    cluster_local_address: ${_param:single_address}
+    cluster_node01_hostname: mon01
+    cluster_node01_address: ${_param:stacklight_monitor_node01_address}
+
+    heka_elasticsearch_host: ${_param:stacklight_monitor_address}
+    heka_influxdb_host: ${_param:stacklight_monitor_address}
+    heka_aggregator_host: ${_param:stacklight_monitor_address}
+
+    aggregator_port: 5565
+
+    grafana_user: admin
+    grafana_password: password
+    grafana_influxdb_host: ${_param:stacklight_monitor_address}
+
+    elasticsearch_port: 9200
+
+    influxdb_stacklight_password: lmapass
+    influxdb_admin_password: password
+    influxdb_port: 8086
+    influxdb_database: lma
+    influxdb_user: lma
+    influxdb_password: lmapass
+
+    kibana_port: 5601
+
+    nagios_host: ${_param:stacklight_monitor_address}
+    nagios_status_port: 8001
+    nagios_username: nagiosadmin
+    nagios_password: secret
+    nagios_notification_smtp_server: 127.0.0.1
+    nagios_notification_from: 'nagios@localhost'
+    nagios_notification_email: 'root@localhost'
+
+    stacklight_environment: ${_param:cluster_domain}
+    stacklight_notification_topic: stacklight_notifications
+  linux:
+    network:
+      host:
+        mon01:
+          address: ${_param:stacklight_monitor_node01_address}
+          names:
+          - mon01
+          - mon01.${_param:cluster_domain}
+        mon:
+          address: ${_param:stacklight_monitor_address}
+          names:
+          - mon
+          - mon.${_param:cluster_domain}

--- a/classes/cluster/mk22_splitted_contrail/stacklight/proxy.yml
+++ b/classes/cluster/mk22_splitted_contrail/stacklight/proxy.yml
@@ -1,0 +1,13 @@
+classes:
+- system.nginx.server.proxy.grafana_web
+- system.nginx.server.proxy.kibana_web
+- system.nginx.server.proxy.nagios_web
+- system.salt.minion.cert.proxy
+- cluster.mk22_splitted_contrail
+parameters:
+  _param:
+    nginx_proxy_ssl:
+      enabled: true
+      authority: ${_param:salt_minion_ca_authority}
+      engine: salt
+      mode: secure

--- a/classes/cluster/mk22_splitted_contrail/stacklight/server.yml
+++ b/classes/cluster/mk22_splitted_contrail/stacklight/server.yml
@@ -1,0 +1,28 @@
+classes:
+- system.linux.system.repo.grafana
+- system.linux.system.repo.influxdb
+- system.linux.system.repo.tcp_elastic
+- system.collectd.remote_client.single
+- system.heka.remote_collector.single
+- system.heka.remote_collector.input.amqp
+- system.heka.aggregator.single
+- system.elasticsearch.server.single
+- system.elasticsearch.server.curator
+- system.influxdb.server.single
+- system.influxdb.database.ceilometer
+- system.kibana.server.single
+- system.grafana.server.single
+- system.nagios.server.single
+- cluster.mk22_splitted_contrail
+parameters:
+  _param:
+    kibana_elasticsearch_host: ${_param:stacklight_monitor_address}
+    collectd_remote_collector_host: localhost
+    heka_amqp_host: ${_param:openstack_message_queue_address}
+  linux:
+    network:
+      interface:
+        ens4:
+          enabled: true
+          type: eth
+          proto: dhcp

--- a/nodes/control/cfg01.mk22-splitted-contrail.local.yml
+++ b/nodes/control/cfg01.mk22-splitted-contrail.local.yml
@@ -1,0 +1,12 @@
+classes:
+- cluster.mk22_splitted_contrail.fuel.config
+- cluster.mk22_splitted_contrail.openstack.proxy
+- cluster.mk22_splitted_contrail.stacklight.proxy
+parameters:
+  _param:
+    linux_system_codename: xenial
+    reclass_data_revision: master
+  linux:
+    system:
+      name: cfg01
+      domain: mk22-splitted-contrail.local


### PR DESCRIPTION
This model is based on mk22_lab_basic but includes
3 additional nodes for OpenContrail control plane
3 others for OpenContrail analytics
1 for Gateway/Proxy to OpenContrail services