### PR TITLE
Deploy InfluxDB in cluster mode

### DIFF
--- a/classes/cluster/mk22_lab_advanced/stacklight/init.yml
+++ b/classes/cluster/mk22_lab_advanced/stacklight/init.yml
@@ -10,14 +10,14 @@ parameters:
     cluster_node03_address: ${_param:stacklight_monitor_node03_address}
 
     heka_elasticsearch_host: ${_param:stacklight_monitor_address}
-    heka_influxdb_host: ${_param:stacklight_monitor_node01_address}
+    heka_influxdb_host: ${_param:stacklight_monitor_address}
     heka_aggregator_host: ${_param:stacklight_monitor_address}
 
     aggregator_port: 5565
 
     grafana_user: admin
     grafana_password: password
-    grafana_influxdb_host: ${_param:stacklight_monitor_node01_address}
+    grafana_influxdb_host: ${_param:stacklight_monitor_address}
 
     elasticsearch_port: 9200
 

--- a/classes/cluster/mk22_lab_advanced/stacklight/server.yml
+++ b/classes/cluster/mk22_lab_advanced/stacklight/server.yml
@@ -10,12 +10,15 @@ classes:
 - system.elasticsearch.server.curator
 - system.kibana.server.single
 - system.grafana.server.single
+- system.influxdb.server.single
+- system.influxdb.database.stacklight
 - system.nagios.server.cluster
 - system.influxdb.database.ceilometer
 - cluster.mk22_lab_advanced
 - system.haproxy.proxy.listen.stacklight.elasticsearch
 - system.haproxy.proxy.listen.stacklight.kibana
 - system.haproxy.proxy.listen.stacklight.grafana
+- system.haproxy.proxy.listen.stacklight.influxdb
 - service.haproxy.proxy.single
 - system.keepalived.cluster.instance.stacklight_monitor_vip
 parameters:
@@ -30,6 +33,7 @@ parameters:
     cluster_elasticsearch_port: 9200
     cluster_kibana_port: 5601
     cluster_grafana_port: 3000
+    cluster_influxdb_port: 8086
     cluster_node01_hostname: mon01
     cluster_node01_address: ${_param:stacklight_monitor_node01_address}
     cluster_node02_hostname: mon02

--- a/classes/cluster/mk22_lab_basic/stacklight/server.yml
+++ b/classes/cluster/mk22_lab_basic/stacklight/server.yml
@@ -10,6 +10,7 @@ classes:
 - system.elasticsearch.server.curator
 - system.influxdb.server.single
 - system.influxdb.database.ceilometer
+- system.influxdb.database.stacklight
 - system.kibana.server.single
 - system.grafana.server.single
 - system.nagios.server.single

--- a/classes/cluster/mk22_lab_dvr/stacklight/init.yml
+++ b/classes/cluster/mk22_lab_dvr/stacklight/init.yml
@@ -1,12 +1,12 @@
 parameters:
   _param:
     heka_elasticsearch_host: ${_param:stacklight_monitor_address}
-    heka_influxdb_host: ${_param:stacklight_monitor_node01_address}
+    heka_influxdb_host: ${_param:stacklight_monitor_address}
     heka_aggregator_host: ${_param:stacklight_monitor_address}
     aggregator_port: 5565
     grafana_user: admin
     grafana_password: password
-    grafana_influxdb_host: ${_param:stacklight_monitor_node01_address}
+    grafana_influxdb_host: ${_param:stacklight_monitor_address}
     elasticsearch_port: 9200
     influxdb_stacklight_password: lmapass
     influxdb_admin_password: password

--- a/classes/cluster/mk22_lab_dvr/stacklight/server.yml
+++ b/classes/cluster/mk22_lab_dvr/stacklight/server.yml
@@ -10,11 +10,14 @@ classes:
 - system.elasticsearch.server.curator
 - system.kibana.server.single
 - system.grafana.server.single
+- system.influxdb.server.single
+- system.influxdb.database.stacklight
 - system.nagios.server.cluster
 - cluster.mk22_lab_dvr
 - system.haproxy.proxy.listen.stacklight.elasticsearch
 - system.haproxy.proxy.listen.stacklight.kibana
 - system.haproxy.proxy.listen.stacklight.grafana
+- system.haproxy.proxy.listen.stacklight.influxdb
 - service.haproxy.proxy.single
 - system.keepalived.cluster.instance.stacklight_monitor_vip
 parameters:
@@ -29,6 +32,7 @@ parameters:
     cluster_elasticsearch_port: 9200
     cluster_kibana_port: 5601
     cluster_grafana_port: 3000
+    cluster_influxdb_port: 8086
     cluster_node01_hostname: mon01
     cluster_node01_address: ${_param:stacklight_monitor_node01_address}
     cluster_node02_hostname: mon02


### PR DESCRIPTION
This change deploys InfluxDB on the 3 monitoring nodes and configures
HAProxy to forward requests only to the first active node. When the
first node fails, traffic will go to the second node (if active) and
eventually to the third node if the second node goes down too. Whenever
the first node comes back online, HAProxy will resume sending the
traffic to it. This is a poor's man HA solution that only ensures that
the operator can visualize the metrics even when the primary node is
unavailable but it doesn't account for data replication at all.