### PR TITLE
Specify control nodes for control panel

### DIFF
--- a/classes/cluster/mk22_lab_dvr/openstack/dashboard.yml
+++ b/classes/cluster/mk22_lab_dvr/openstack/dashboard.yml
@@ -10,6 +10,10 @@ parameters:
         prd:
           host: ${_param:stacklight_monitor_address}
           port: 4567
+      control_nodes:
+        ctl01: ${_param:cluster_node01_hostname}.${_param:cluster_domain}
+        ctl02: ${_param:cluster_node02_hostname}.${_param:cluster_domain}
+        ctl03: ${_param:cluster_node03_hostname}.${_param:cluster_domain}
       plugin:
         monitoring:
           app: horizon_monitoring


### PR DESCRIPTION
This specifies the control nodes mapping used by the Horizon Telemetry
plugin to configure the control panel.