### PR TITLE
Disable sensu check for all services

### DIFF
--- a/classes/cluster/mk22_lab_dvr/init.yml
+++ b/classes/cluster/mk22_lab_dvr/init.yml
@@ -45,6 +45,9 @@ parameters:
     rabbitmq_monitor_password: 'password'
     rabbitmq_monitor_port: 5672
   linux:
+    _support:
+      sensu:
+        enabled: false
     network:
       host:
         cmp01:
@@ -57,11 +60,27 @@ parameters:
           names:
           - cmp02
           - cmp02.${_param:cluster_domain}
+  apache:
+    _support:
+      sensu:
+        enabled: false
   cinder:
     _support:
       sensu:
         enabled: false
+  collectd:
+    _support:
+      sensu:
+        enabled: false
+  elasticsearch:
+    _support:
+      sensu:
+        enabled: false
   glance:
+    _support:
+      sensu:
+        enabled: false
+  glusterfs:
     _support:
       sensu:
         enabled: false
@@ -73,6 +92,10 @@ parameters:
     _support:
       sensu:
         enabled: false
+  keepalived:
+    _support:
+      sensu:
+        enabled: false
   keystone:
     _support:
       sensu:
@@ -81,7 +104,15 @@ parameters:
     _support:
       sensu:
         enabled: false
+  nginx:
+    _support:
+      sensu:
+        enabled: false
   nova:
+    _support:
+      sensu:
+        enabled: false
+  ntp:
     _support:
       sensu:
         enabled: false


### PR DESCRIPTION
As many checks are done by StackLight we disable all checks done by
Sensu and we will enable them only if we need them. We also do that
because currently it generates red alerts so lets fix this one by one
and when needed.