### PR TITLE
Update check for local salt master

### DIFF
--- a/classes/cluster/mk22_lab_dvr/init.yml
+++ b/classes/cluster/mk22_lab_dvr/init.yml
@@ -60,6 +60,10 @@ parameters:
           names:
           - cmp02
           - cmp02.${_param:cluster_domain}
+  sensu:
+    check:
+      local_salt_master_proc:
+        command: "PATH=$PATH:/usr/lib64/nagios/plugins:/usr/lib/nagios/plugins check_procs -C salt-master -u root -c 1:50"
   apache:
     _support:
       sensu:


### PR DESCRIPTION
By default the check is OK for a number of processes between 1 and 15
but on our machine the number is up to 48. So we set the limit
accordingly.