### PR TITLE
Enable local check for Elasticsearch

### DIFF
--- a/classes/cluster/mk22_lab_dvr/init.yml
+++ b/classes/cluster/mk22_lab_dvr/init.yml
@@ -72,10 +72,6 @@ parameters:
     _support:
       sensu:
         enabled: false
-  elasticsearch:
-    _support:
-      sensu:
-        enabled: false
   glance:
     _support:
       sensu:


### PR DESCRIPTION
This activates the check local_elasticsearch_server_proc that runs the
command "check_procs -C java -u elasticsearch -c 1:1" on all monitoring
nodes.